### PR TITLE
Fixed hard coded value in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       until postgres/bin/pg_isready -h ${COMPOSE_PROJECT_NAME}-yb-2 ; do sleep 1 ; done | uniq
       yugabyted configure data_placement --constraint_value cloud.region1.zone:1,cloud.region2.zone:2,cloud.region3.zone:3
      fi
-     cloud_location=cloud.region$$(ysqlsh -h yb-compose-yb-1 -tAc "select count(*)%3+1 from yb_servers()" ).zone
+     cloud_location=cloud.region$$(ysqlsh -h ${COMPOSE_PROJECT_NAME}-yb-1 -tAc "select count(*)%3+1 from yb_servers()" ).zone
      yugabyted start --join=${COMPOSE_PROJECT_NAME}-yb-1 --advertise_address=$$(hostname) --cloud_location=$$cloud_location $$other_flags
     fi
     # add network delay to add to simulate distance between nodes


### PR DESCRIPTION
One place still had a hard-coded value for the docker compose project name, which did not work in my setup.